### PR TITLE
updates needed for php7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y \
-                ca-certificates curl cron git supervisor mysql-client vim unzip \
-		libxml2-dev mime-support ssmtp \
-		php7.0-fpm php7.0-curl php7.0-gd php7.0-mysql php7.0-mcrypt php7.0-gmp php7.0-ldap php7.0-zip \
-		php7.0-bcmath php-pear php-console-table php-apcu php-mongodb php-ssh2 \
-		apache2 \
-        --no-install-recommends && apt-get -y upgrade && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y python-software-properties software-properties-common \
+  --no-install-recommends --allow-unauthenticated
+RUN add-apt-repository ppa:ondrej/php -y | echo 0
+RUN apt-get update && apt-get install -y --allow-unauthenticated --no-install-recommends \
+    ca-certificates curl cron git supervisor mysql-client vim unzip libxml2-dev mime-support ssmtp \
+    php7.2-fpm php7.2-curl php7.2-gd php7.2-mysql php7.2-gmp php7.2-ldap php7.2-zip \
+    php7.2-bcmath php-pear php-console-table php-apcu php-mongodb php-ssh2 \
+    apache2 && apt-get -y --allow-unauthenticated upgrade && rm -r /var/lib/apt/lists/*
 
 RUN a2enmod ssl rewrite proxy_fcgi headers remoteip
 
@@ -29,8 +30,8 @@ ADD https://github.com/kelseyhightower/confd/releases/download/v0.11.0/confd-0.1
 RUN chmod +x /usr/local/bin/confd
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-COPY www.conf /etc/php/7.0/fpm/pool.d/www.conf
-COPY php.ini /etc/php/7.0/fpm/php.ini
+COPY www.conf /etc/php/7.2/fpm/pool.d/www.conf
+COPY php.ini /etc/php/7.2/fpm/php.ini
 COPY site.conf /etc/apache2/sites-available/000-default.conf
 COPY remoteip.conf /etc/apache2/conf-enabled/remoteip.conf
 COPY confd /etc/confd/

--- a/start.sh
+++ b/start.sh
@@ -39,7 +39,7 @@ if [[ -n "$LOCAL" &&  $LOCAL = "true" ]] ; then
   /usr/bin/apt-get update && apt-get install -y \
     php-xdebug \
     --no-install-recommends && rm -r /var/lib/apt/lists/*
-  cp /root/xdebug-php.ini /etc/php/7.0/fpm/php.ini
+  cp /root/xdebug-php.ini /etc/php/7.2/fpm/php.ini
   /usr/bin/supervisorctl restart php-fpm
 fi
 
@@ -77,8 +77,8 @@ else
 fi
 
 # set permissions on php log
-chmod 640 /var/log/php7.0-fpm.log
-chown www-data:www-data /var/log/php7.0-fpm.log
+chmod 640 /var/log/php7.2-fpm.log
+chown www-data:www-data /var/log/php7.2-fpm.log
 
 crontab /root/crons.conf
 /usr/bin/supervisorctl restart apache2

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -18,7 +18,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:php-fpm]
-command=/usr/sbin/php-fpm7.0 -F -O
+command=/usr/sbin/php-fpm7.2 -F -O
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
Added the repo for newer versions of php, changed everything to php7.2.
Added the line `add-apt-repository ppa:ondrej/php -y | echo 0` separate because otherwise the command didn't exist and the echo 0 makes it work as it was mad that didn't return a 0. It's a bad hack.
I also skipped adding php7.2-mcrypt as it wasn't downloading, not sure what it does and if it's needed.
Can be tested as the docker image `fabean/drupal:php7.2`

Would in Docker want to take what's currently there and tag it php7.0 then make this the tag php7.2 and once tested and working properly it can be moved to latest.